### PR TITLE
Update x-mitre-tactic--da7738af-46f6-4bc6-bfa2-91a466439391.json

### DIFF
--- a/mbc/x-mitre-tactic/x-mitre-tactic--da7738af-46f6-4bc6-bfa2-91a466439391.json
+++ b/mbc/x-mitre-tactic/x-mitre-tactic--da7738af-46f6-4bc6-bfa2-91a466439391.json
@@ -15,7 +15,7 @@
                 {
                     "source_name": "mitre-mbc",
                     "url": "https://github.com/MBCProject/mbc-markdown/blob/v2.3/credential-access/README.md",
-                    "external_id": "OB0006"
+                    "external_id": "OB0005"
                 }
             ],
             "object_marking_refs": [


### PR DESCRIPTION
Defense Evasion and Credential Access had duplicate IDs. Credential Access should have been OB0005.